### PR TITLE
fix(e2e):save e2e key variants correctly on workspace creation

### DIFF
--- a/lumium-api/src/entity/E2EKey.ts
+++ b/lumium-api/src/entity/E2EKey.ts
@@ -1,15 +1,16 @@
 import { Column, Entity, OneToMany, OneToOne } from "typeorm";
+import { E2EKeyCreateDTO } from "../../types";
 import { E2EKeyDTO } from "../../types/api/v1/dto/entity/E2EKeyDTO";
 import { AbstractEntity } from "./AbstractEntity";
-import { E2EKeyVariant, mapToE2EKeyVariantDTO } from "./E2EKeyVariant";
+import { E2EKeyVariant, mapToE2EKeyVariant, mapToE2EKeyVariantDTO } from "./E2EKeyVariant";
 import { Workspace } from "./Workspace";
 
 @Entity('end_to_end_keys')
 export class E2EKey extends AbstractEntity {
-    @OneToOne(() => Workspace, (workspace) => workspace.key)
-    workspace: Workspace
+    @OneToOne(() => Workspace, (workspace) => workspace.key, { cascade: true, onDelete: 'CASCADE' })
+    workspace?: Workspace
 
-    @OneToMany(() => E2EKeyVariant, (variant) => variant.key)
+    @OneToMany(() => E2EKeyVariant, (variant) => variant.key, { eager: true })
     keys: E2EKeyVariant[]
 
     @Column()
@@ -29,3 +30,11 @@ export const mapToE2EKeyDTO = (entity: E2EKey) => {
     };
     return dto;
 }
+
+export const mapToE2EKey = (dto: E2EKeyCreateDTO) => {
+    let entity: E2EKey = {
+        keys: dto.keys.map(mapToE2EKeyVariant),
+        activator: dto.activator
+    };
+    return entity;
+};

--- a/lumium-api/src/entity/E2EKeyVariant.ts
+++ b/lumium-api/src/entity/E2EKeyVariant.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, ManyToOne } from "typeorm";
+import { E2EKeyVariantCreateDTO } from "../../types";
 import { E2EKeyVariantDTO } from "../../types/api/v1/dto/entity/E2EKeyVariantDTO";
 import { AbstractEntity } from "./AbstractEntity";
 import { E2EKey } from "./E2EKey";
@@ -6,7 +7,7 @@ import { E2EKey } from "./E2EKey";
 @Entity('end_to_end_key_variants')
 export class E2EKeyVariant extends AbstractEntity {
     @ManyToOne(() => E2EKey, (key) => key.keys, { cascade: true, onDelete: 'CASCADE' })
-    key: E2EKey
+    key?: E2EKey
 
     @Column()
     activator: string
@@ -39,4 +40,14 @@ export const mapToE2EKeyVariantDTO = (entity: E2EKeyVariant) => {
         version: entity.version
     };
     return dto;
+};
+
+export const mapToE2EKeyVariant = (dto: E2EKeyVariantCreateDTO) => {
+    let entity: E2EKeyVariant = {
+        activator: dto.activator,
+        activatorNonce: dto.activatorNonce,
+        value: dto.value,
+        valueNonce: dto.valueNonce,
+    };
+    return entity;
 };

--- a/lumium-api/src/entity/Workspace.ts
+++ b/lumium-api/src/entity/Workspace.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, JoinColumn, JoinTable, ManyToMany, ManyToOne, OneToMany, OneToOne } from "typeorm";
-import { WorkspaceDTO } from "../../types";
+import { WorkspaceCreateDTO, WorkspaceDTO } from "../../types";
 import { AbstractEntity } from "./AbstractEntity";
-import { E2EKey, mapToE2EKeyDTO } from "./E2EKey";
+import { E2EKey, mapToE2EKey, mapToE2EKeyDTO } from "./E2EKey";
 import { mapToPageDTO, Page } from "./Page";
 import { User } from "./User";
 import { mapToWorkspacePreferenceDTO, WorkspacePreference } from "./WorkspacePreference";
@@ -29,7 +29,7 @@ export class Workspace extends AbstractEntity {
     @OneToMany(() => WorkspacePreference, (workspacePreferences) => workspacePreferences.workspace)
     preferences: WorkspacePreference[]
 
-    @OneToOne(() => E2EKey, (e2eKey) => e2eKey.workspace, { cascade: true, onDelete: 'CASCADE' })
+    @OneToOne(() => E2EKey, (e2eKey) => e2eKey.workspace)
     @JoinColumn()
     key: E2EKey
 
@@ -54,4 +54,18 @@ export const mapToWorkspaceDTO = (entity: Workspace) => {
         version: entity.version
     };
     return dto;
+};
+
+export const mapToWorkspace = (dto: WorkspaceCreateDTO) => {
+    let entity: Workspace = {
+        owner: null,
+        admins: null,
+        members: null,
+        visitors: null,
+        pages: null,
+        preferences: null,
+        key: mapToE2EKey(dto.key),
+        name: dto.name
+    };
+    return entity;
 };

--- a/lumium-api/src/migration/1671487559078-test.ts
+++ b/lumium-api/src/migration/1671487559078-test.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class test1671487559078 implements MigrationInterface {
+    name = 'test1671487559078'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "workspaces" DROP CONSTRAINT "FK_4c0073fedaf9eb9e91851fe4adc"`);
+        await queryRunner.query(`ALTER TABLE "workspace_preferences" DROP COLUMN "option"`);
+        await queryRunner.query(`ALTER TABLE "workspace_preferences" ADD "option" "public"."workspace_preferences_option_enum" NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "workspaces" ADD CONSTRAINT "FK_4c0073fedaf9eb9e91851fe4adc" FOREIGN KEY ("keyId") REFERENCES "end_to_end_keys"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "workspaces" DROP CONSTRAINT "FK_4c0073fedaf9eb9e91851fe4adc"`);
+        await queryRunner.query(`ALTER TABLE "workspace_preferences" DROP COLUMN "option"`);
+        await queryRunner.query(`ALTER TABLE "workspace_preferences" ADD "option" workspace_preferences_option_enum NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "workspaces" ADD CONSTRAINT "FK_4c0073fedaf9eb9e91851fe4adc" FOREIGN KEY ("keyId") REFERENCES "end_to_end_keys"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}


### PR DESCRIPTION
this commit fixes an issue whereby `E2EKeyCreateDTO.keys` didn't
actually get persisted to the database, and therefore the endpoint was
completely useless. this is now fixed.
